### PR TITLE
Migrate to a static-web-server docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.*
+Dockerfile
+LICENSE
+README.md

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: "Deploy"
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy to Sliplane.io
+    steps:
+      - uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: type=edge
+        id: meta
+      - uses: actions/checkout@v6
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:cache,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: runtime
+      - run: |
+          curl "https://api.sliplane.io/deploy/service_3tmx8qpzz8gw/${{ secrets.SLIPLANE_SECRET }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM joseluisq/static-web-server:2 AS runtime
+
+COPY . /var/public/
+ENTRYPOINT ["/static-web-server", "--root=/var/public", "--health"]


### PR DESCRIPTION
Adds a docker file which serves the entire site using a rust-based server, published to ghcr.io and deployed to sliplane.io.